### PR TITLE
DrawerをPopover APIを使う実装へ変更した

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shikakun.com",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "packageManager": "yarn@3.6.1",

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "sanitize-html": "^2.11.0",
     "sass": "^1.65.1",
     "xml2js": "^0.6.2"
+  },
+  "dependencies": {
+    "@oddbird/popover-polyfill": "^0.3.1"
   }
 }

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -10,8 +10,7 @@ const {
   rel,
   data,
   ariaLabel,
-  ariaExpanded,
-  ariacontrols,
+  popovertarget,
   appearance,
   width,
   leadingIcon,
@@ -51,8 +50,6 @@ if (width == 'full') {
       rel={rel}
       data={data}
       aria-label={ariaLabel}
-      aria-expanded={ariaExpanded}
-      aria-controls={ariacontrols}
     >
       {leadingIcon ? (
         <div class='leading'>
@@ -80,8 +77,7 @@ if (width == 'full') {
       class={classes}
       data={data}
       aria-label={ariaLabel}
-      aria-expanded={ariaExpanded}
-      aria-controls={ariacontrols}
+      popovertarget={popovertarget}
     >
       {leadingIcon ? (
         <div class='leading'>

--- a/src/components/Drawer.astro
+++ b/src/components/Drawer.astro
@@ -1,8 +1,12 @@
 ---
 import ArticleFilter from '@components/ArticleFilter.astro';
+import Button from '@components/Button.astro';
 ---
 
 <nav id='drawer' class='drawer' popover>
+  <button class='backdrop' popovertarget='drawer' tabindex="-1" aria-hidden="true">
+    <span class='visually-hidden'>閉じる</span>
+  </button>
   <div class='container'>
     <div class='menu'>
       <ul>
@@ -15,6 +19,16 @@ import ArticleFilter from '@components/ArticleFilter.astro';
 
     <div class='filter'>
       <ArticleFilter />
+    </div>
+
+    <div class='close'>
+      <Button
+        element='button'
+        leadingIcon='cross'
+        popovertarget='drawer'
+      >
+        メニューを閉じる
+      </Button>
     </div>
   </div>
 </nav>
@@ -55,6 +69,7 @@ import ArticleFilter from '@components/ArticleFilter.astro';
 
   .drawer {
     @include mixins.initialize(popover);
+    box-sizing: border-box;
     position: fixed;
     top: 0;
     right: 0;
@@ -62,31 +77,26 @@ import ArticleFilter from '@components/ArticleFilter.astro';
     left: 0;
     width: 100%;
     height: 100%;
-    background: transparent;
+    background-color: rgba(functions.get-primitive-color(blue, 600), 0.8);
+    backdrop-filter: blur(0.25rem);
     z-index: 1000;
     overflow-x: hidden;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
-    pointer-events: none;
+  }
 
-    &::backdrop {
-      position: fixed;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      background-color: rgba(functions.get-primitive-color(blue, 600), 0.8);
-      backdrop-filter: blur(0.25rem);
-    }
+  .backdrop {
+    @include mixins.initialize(button);
+    display: block;
+    width: 100%;
+    height: 50vh;
   }
 
   .container {
     position: relative;
-    margin-top: 50vh;
-    min-height: 50vh;
     width: 100%;
+    min-height: 50vh;
     background-color: functions.get-primitive-color(white);
-    pointer-events: auto;
   }
 
   .menu {
@@ -121,5 +131,10 @@ import ArticleFilter from '@components/ArticleFilter.astro';
 
   .filter {
     padding: functions.get-spacing-size(l);
+  }
+
+  .close {
+    margin-top: functions.get-spacing-size(7xl);
+    padding: 0 functions.get-spacing-size(xs) functions.get-spacing-size(m);
   }
 </style>

--- a/src/components/Drawer.astro
+++ b/src/components/Drawer.astro
@@ -20,10 +20,16 @@ import ArticleFilter from '@components/ArticleFilter.astro';
 </nav>
 
 <script>
+  import { isSupported, apply } from 'node_modules/@oddbird/popover-polyfill/dist/popover-fn.js';
+
   window.addEventListener('load', () => {
     const body = document.body;
     const drawer = document.getElementById('drawer');
     const contents = document.getElementById('contents');
+
+    if (!isSupported()) {
+      apply();
+    }
 
     drawer.addEventListener("toggle", (event) => {
       if (event.newState === 'open') {

--- a/src/components/Drawer.astro
+++ b/src/components/Drawer.astro
@@ -21,13 +21,20 @@ import ArticleFilter from '@components/ArticleFilter.astro';
 
 <script>
   window.addEventListener('load', () => {
+    const body = document.body;
     const drawer = document.getElementById('drawer');
+    const contents = document.getElementById('contents');
 
     drawer.addEventListener("toggle", (event) => {
       if (event.newState === 'open') {
-        document.body.style.overflow = 'hidden';
+        body.style.overflow = 'hidden';
+        contents.setAttribute('aria-hidden', 'true');
+        contents.setAttribute('inert', 'inert');
+
       } else {
-        document.body.style.overflow = 'auto';
+        body.style.overflow = 'auto';
+        contents.setAttribute('aria-hidden', 'false');
+        contents.removeAttribute('inert');
       }
     });
   });

--- a/src/components/Drawer.astro
+++ b/src/components/Drawer.astro
@@ -1,7 +1,5 @@
 ---
 import ArticleFilter from '@components/ArticleFilter.astro';
-
-const { avatar } = Astro.props;
 ---
 
 <nav id='drawer' class='drawer' aria-hidden='true'>

--- a/src/components/Drawer.astro
+++ b/src/components/Drawer.astro
@@ -2,17 +2,11 @@
 import ArticleFilter from '@components/ArticleFilter.astro';
 ---
 
-<nav id='drawer' class='drawer' aria-hidden='true'>
-  <div
-    class='background js-drawer-switch'
-    aria-expanded='true'
-    aria-controls='drawer'
-  >
-  </div>
+<nav id='drawer' class='drawer' popover>
   <div class='container'>
     <div class='menu'>
       <ul>
-        <li><a href='/' rel='home'>Profile</a></li>
+        <li><a href='/' rel='home' autofocus>Profile</a></li>
         <li><a href='/articles/'>Articles</a></li>
         <li><a href='/link/'>Link</a></li>
         <li><a href='/manzai/'>Manzai</a></li>
@@ -25,6 +19,20 @@ import ArticleFilter from '@components/ArticleFilter.astro';
   </div>
 </nav>
 
+<script>
+  window.addEventListener('load', () => {
+    const drawer = document.getElementById('drawer');
+
+    drawer.addEventListener("toggle", (event) => {
+      if (event.newState === 'open') {
+        document.body.style.overflow = 'hidden';
+      } else {
+        document.body.style.overflow = 'auto';
+      }
+    });
+  });
+</script>
+
 <style lang='scss'>
   @use '@styles/variables';
   @use '@styles/functions';
@@ -33,30 +41,30 @@ import ArticleFilter from '@components/ArticleFilter.astro';
   @use 'sass:map';
 
   .drawer {
+    @include mixins.initialize(popover);
     position: fixed;
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
+    width: 100%;
+    height: 100%;
+    background: transparent;
     z-index: 1000;
     overflow-x: hidden;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
+    pointer-events: none;
 
-    &[aria-hidden='true'] {
-      visibility: hidden;
-      opacity: 0;
+    &::backdrop {
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      background-color: rgba(functions.get-primitive-color(blue, 600), 0.8);
+      backdrop-filter: blur(0.25rem);
     }
-  }
-
-  .background {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    background-color: rgba(functions.get-primitive-color(blue, 600), 0.8);
-    backdrop-filter: blur(0.25rem);
   }
 
   .container {
@@ -65,10 +73,7 @@ import ArticleFilter from '@components/ArticleFilter.astro';
     min-height: 50vh;
     width: 100%;
     background-color: functions.get-primitive-color(white);
-  }
-
-  .drawer[aria-hidden='true'] .container {
-    opacity: 0;
+    pointer-events: auto;
   }
 
   .menu {
@@ -103,9 +108,5 @@ import ArticleFilter from '@components/ArticleFilter.astro';
 
   .filter {
     padding: functions.get-spacing-size(l);
-  }
-
-  body[data-drawer-opened='true'] {
-    overflow: hidden;
   }
 </style>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,11 +1,9 @@
 ---
 import Button from '@components/Button.astro';
-
-const { avatar } = Astro.props;
 ---
 
 <div class='wrapper'>
-  <div class='avatar' data-show-avatar={avatar}>
+  <div class='avatar'>
     <a href='/' rel='home' tabindex='-1'>
       <img src='/images/brand/shikakun_square.png' alt='' />
     </a>
@@ -120,14 +118,6 @@ const { avatar } = Astro.props;
     padding: 1rem;
     @include mixins.mq-boundary(up, m) {
       padding: 2rem;
-    }
-
-    &[data-show-avatar='false'] {
-      opacity: 0;
-      pointer-events: none;
-      @include mixins.mq-boundary(down, m) {
-        width: 0;
-      }
     }
 
     a {

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -30,12 +30,10 @@ import Button from '@components/Button.astro';
   <div class='launcher'>
     <Button
       element='button'
-      className='js-drawer-switch'
       leadingIcon='menu'
       iconOnly='true'
       ariaLabel='メニュー'
-      ariaExpanded='false'
-      ariacontrols='drawer'
+      popovertarget='drawer'
     >
       メニュー
     </Button>
@@ -43,22 +41,6 @@ import Button from '@components/Button.astro';
 </div>
 
 <script>
-  window.addEventListener('load', () => {
-    const drawerSwitches = document.querySelectorAll('.js-drawer-switch');
-
-    drawerSwitches.forEach(function (switchElement) {
-      switchElement.addEventListener('click', function () {
-        const controlledElementId = this.getAttribute('aria-controls');
-        const controlledElement = document.getElementById(controlledElementId);
-        const isHidden =
-          controlledElement.getAttribute('aria-hidden') === 'true';
-
-        controlledElement.setAttribute('aria-hidden', !isHidden);
-        document.body.setAttribute('data-drawer-opened', isHidden);
-      });
-    });
-  });
-
   window.addEventListener('load', () => {
     const links = document.querySelectorAll('.js-text-effect-link');
     const tempChars = 'abcdefhiklmnorstuvwxz';

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -56,11 +56,11 @@ const { title, description, openGraph } = Astro.props;
   <body>
     <GoogleTagManager position='body' />
     <header class='header'>
-      <Navbar avatar='true' />
+      <Navbar />
     </header>
     <slot />
     <footer class='footer'>
-      <Navbar avatar='false' />
+      <Navbar />
     </footer>
     <Drawer />
     <script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -55,14 +55,21 @@ const { title, description, openGraph } = Astro.props;
   </head>
   <body>
     <GoogleTagManager position='body' />
-    <header class='header'>
-      <Navbar />
-    </header>
-    <slot />
-    <footer class='footer'>
-      <Navbar />
-    </footer>
+
+    <div id="contents">
+      <header class='header'>
+        <Navbar />
+      </header>
+
+      <slot />
+
+      <footer class='footer'>
+        <Navbar />
+      </footer>
+    </div>
+
     <Drawer />
+
     <script>
       (function (d) {
         var config = {

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -458,7 +458,10 @@
   }
 
   // popover {
-  //
+  //   color: inherit;
+  //   border: 0;
+  //   margin: 0;
+  //   padding: 0;
   // }
   @else if $element == popover {
     color: inherit;

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -457,6 +457,15 @@
     margin: 0;
   }
 
+  // popover {
+  //
+  // }
+  @else if $element == popover {
+    border: 0;
+    margin: 0;
+    padding: 0;
+  }
+
   // small {
   //   font-size: 100%;
   // }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -461,6 +461,7 @@
   //
   // }
   @else if $element == popover {
+    color: inherit;
     border: 0;
     margin: 0;
     padding: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,6 +906,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oddbird/popover-polyfill@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@oddbird/popover-polyfill@npm:0.3.1"
+  checksum: d242c13ea7776b0afdc2bce6815406c9152bc92825bcf53e12d21012b10d315bd822d364f48af1365ccee8e57bc89bd356171febedfa6cfa19f36e75d8c08354
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -5683,6 +5690,7 @@ __metadata:
   resolution: "shikakun.com@workspace:."
   dependencies:
     "@astrojs/react": ^3.0.4
+    "@oddbird/popover-polyfill": ^0.3.1
     "@types/react": ^18.2.20
     "@types/react-dom": ^18.2.7
     astro: ^3.4.0


### PR DESCRIPTION
ドロワーメニューのアクセシビリティを高めるために、Popover APIを使う実装へ変更したほか、ドロワーメニューを開いているときは背景に表示されているコンテンツを操作できないように非活性化するようにしました。
🔗 [ポップオーバー API - Web API | MDN](https://developer.mozilla.org/ja/docs/Web/API/Popover_API)
🔗 [oddbird/popover-polyfill](https://github.com/oddbird/popover-polyfill)
🔗 [HTMLElement: inert プロパティ - Web API | MDN](https://developer.mozilla.org/ja/docs/Web/API/HTMLElement/inert)